### PR TITLE
Upgrade to docker 24/buildx 0.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
-FROM docker/buildx-bin:v0.8 as buildx
+FROM docker/buildx-bin:v0.12 as buildx
 
-FROM docker:20
+FROM docker:24-dind
 
-RUN apk add bash ip6tables pigz sysstat procps lsof
+RUN apk add bash iptables-legacy pigz sysstat procps lsof \
+    && mv /sbin/iptables /sbin/iptables.original \
+    && mv /sbin/ip6tables /sbin/ip6tables.original \
+    && ln -s /sbin/iptables-legacy /sbin/iptables \
+    && ln -s /sbin/ip6tables-legacy /sbin/ip6tables
 
 COPY etc/docker/daemon.json /etc/docker/daemon.json
 

--- a/docker-entrypoint.d/docker
+++ b/docker-entrypoint.d/docker
@@ -6,6 +6,6 @@ echo "Setting up Docker data directory"
 mkdir -p /data/docker
 
 echo "Configuring ipv6 for docker"
-ip6tables -t nat -A POSTROUTING -s 2001:db8:1::/64 ! -o docker0 -j MASQUERADE
+ip6tables-legacy -t nat -A POSTROUTING -s 2001:db8:1::/64 ! -o docker0 -j MASQUERADE
 
 echo "Done setting up docker!"

--- a/etc/docker/daemon.json
+++ b/etc/docker/daemon.json
@@ -13,7 +13,7 @@
     "debug": true,
     "log-level": "debug",
     "features": {
-        "buildkit": false
+        "buildkit": true
     },
     "hosts": [
         "unix:///var/run/docker.sock",


### PR DESCRIPTION
Use iptables-legacy to avoid the following:

```
unable to detect if iptables supports xlock: 'iptables --wait -L -n': `iptables v1.8.10 (nf_tables): Could not fetch rule set generation id: Invalid argument`  error="exit status 4"
```